### PR TITLE
Fix ConfigError being shown on first load - causing a subsequent refresh 

### DIFF
--- a/platform/src/EducationPlatformApp.js
+++ b/platform/src/EducationPlatformApp.js
@@ -772,7 +772,9 @@ class EducationPlatformApp {
     }
 
 
-    async showBranches() {
+    async showBranches(event) {
+        event.preventDefault();
+
         const activityURL = utility.getActivityURL();
         try {
             // Retrieve a list of branches in the repository


### PR DESCRIPTION
Occasionally the website would show a ConfigError on load, and we would have to refresh the website to load the activities properly. After a lot of debugging to pinpoint the problem, I saw it was because of a trailing '#' being appended to the URL when an anchor tag (i.e Save / Branches) was being clicked. This caused the COMMON_UTILITY_URL in EducationPlatformApp.js to be computed incorrectly, and as such this down the line this wrong value would be caught in an error. 

a href = "#" tags automatically append a # when clicked, so it is necessary to write event.preventDefault() in the corresponding function so it does not do this, and the URL remains valid. 

We can also fix this by writing a href="javascript:void(0)", which maps the anchor tag to a void function, however for simplicity and readability in the index.html file I opted to instead control the behaviour in its javascript function. 